### PR TITLE
Checking for arrays before object

### DIFF
--- a/lib/for-each.js
+++ b/lib/for-each.js
@@ -33,11 +33,11 @@ const forEach = _.curry(function forEach(fn, data) {
             fn = co.wrap(fn);
         }
 
-        //objects
-        if(_.isObject(data)) {
+        //arrays
+        if (_.isArray(data)) {
             let returnedData = [];
-            for(let key in data) {
-                returnedData.push(fn(data[key], key));
+            for(let i = 0; i < data.length; i++) {
+                returnedData.push(fn(data[i], i));
             }
             if(returnedData.length > 0) {
                 if(util.isPromise(returnedData[0])) {
@@ -46,11 +46,11 @@ const forEach = _.curry(function forEach(fn, data) {
             }
         }
 
-        //arrays
-        else if (_.isArray(data)) {
+        //objects
+        else if(_.isObject(data)) {
             let returnedData = [];
-            for(let i = 0; i < data.length; i++) {
-                returnedData.push(fn(data[i], i));
+            for(let key in data) {
+                returnedData.push(fn(data[key], key));
             }
             if(returnedData.length > 0) {
                 if(util.isPromise(returnedData[0])) {

--- a/lib/map.js
+++ b/lib/map.js
@@ -33,8 +33,21 @@ const map = _.curry(function map(fn, data) {
             fn = co.wrap(fn);
         }
 
+        //arrays
+        if (_.isArray(data)) {
+            //map into array of Promises
+            let results = data.map((n, key) => fn(n, key));
+            if(results.length < 1) {
+                return [];
+            }
+            if(util.isPromise(results[0])) {
+                results = yield results;
+            }
+            return results;
+        }
+
         //objects
-        if(_.isObject(data)) {
+        else if(_.isObject(data)) {
             
             //we don't want to modify the target
             let clonedData = _.cloneDeep(data);
@@ -59,19 +72,6 @@ const map = _.curry(function map(fn, data) {
             }
 
             return clonedData;
-        }
-
-        //arrays
-        else if (_.isArray(data)) {
-            //map into array of Promises
-            let results = data.map((n, key) => fn(n, key));
-            if(results.length < 1) {
-                return [];
-            }
-            if(util.isPromise(results[0])) {
-                results = yield results;
-            }
-            return results;
         }
 
         //error


### PR DESCRIPTION
Latest version of lodash has plenty of breaking changes and it is one of those. According to their docs https://lodash.com/docs/#isObject. An array is also a valid `isObject`. So we need to move array checking up in this list.
